### PR TITLE
add dropdown/nested dialog demos

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,9 @@
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "paper-button": "PolymerElements/paper-button#^1.0.0",
+    "paper-dropdown-menu": "PolymerElements/paper-dropdown-menu#^1.0.0",
+    "paper-menu": "PolymerElements/paper-menu#^1.0.0",
+    "paper-item": "PolymerElements/paper-item#^1.0.0",
     "paper-dialog-scrollable": "PolymerElements/paper-dialog-scrollable#^1.0.0",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
     "web-component-tester": "*",

--- a/demo/index.html
+++ b/demo/index.html
@@ -25,6 +25,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../paper-styles/paper-styles.html">
   <link rel="import" href="../../paper-styles/demo-pages.html">
   <link rel="import" href="../../neon-animation/neon-animations.html">
+  <link rel="import" href="../../paper-dropdown-menu/paper-dropdown-menu.html">
+  <link rel="import" href="../../paper-menu/paper-menu.html">
+  <link rel="import" href="../../paper-item/paper-item.html">
 
   <link rel="stylesheet" href="../../paper-styles/demo.css">
 
@@ -50,11 +53,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       position: fixed;
       top: 16px;
       right: 16px;
-    }
-
-    paper-dialog.size-position {
       width: 300px;
       height: 300px;
+      overflow: auto;
     }
   </style>
 
@@ -68,6 +69,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <paper-button data-dialog="scrolling">scrolling dialog</paper-button>
     <paper-button data-dialog="actions">dialog with actions</paper-button>
     <paper-button data-dialog="modal">modal dialog</paper-button>
+    <paper-button data-dialog="dropdown">dialog with dropdown</paper-button>
+    <paper-button data-dialog="nested">dialog with nested dialog</paper-button>
 
     <paper-dialog id="dialog">
       <h2>Dialog Title</h2>
@@ -108,6 +111,37 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <paper-button dialog-confirm autofocus>Tap me to close</paper-button>
       </div>
     </paper-dialog>
+
+    <paper-dialog id="dropdown">
+    <h2>Dialog Title</h2>
+    <paper-dropdown-menu label="Value">
+      <paper-menu class="dropdown-content">
+        <paper-item>1</paper-item>
+        <paper-item>2</paper-item>
+        <paper-item>3</paper-item>
+        <paper-item>4</paper-item>
+        <paper-item>5</paper-item>
+        <paper-item>6</paper-item>
+        <paper-item>7</paper-item>
+        <paper-item>8</paper-item>
+        <paper-item>9</paper-item>
+        <paper-item>10</paper-item>
+      </paper-menu>
+    </paper-dropdown-menu>
+  </paper-dialog>
+
+  <paper-dialog id="nested">
+    <h2>Dialog Title</h2>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <div class="buttons">
+      <paper-button data-dialog="innerDialog">Open nested dialog</paper-button>
+    </div>
+  </paper-dialog>
+
+  <paper-dialog id="innerDialog">
+    <h2>Dialog Title</h2>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+  </paper-dialog>
 
   </section>
 


### PR DESCRIPTION
Added two demos for special dialog cases: a dropdown inside a dialog, and a dialog inside a dialog

Once https://github.com/PolymerElements/paper-dialog-behavior/pull/30 lands, the dropdown demo should look nice too.

<img width="923" alt="screen shot 2015-09-28 at 12 16 56 pm" src="https://cloud.githubusercontent.com/assets/1369170/10146026/798096ce-65db-11e5-8bfb-fc33b77ccebd.png">
<img width="933" alt="screen shot 2015-09-28 at 12 17 10 pm" src="https://cloud.githubusercontent.com/assets/1369170/10146025/797fca0a-65db-11e5-891c-c237889ba3fa.png">
