### PR TITLE
get rid of section's highlight (ios)

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -32,6 +32,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="stylesheet" href="../../paper-styles/demo.css">
 
   <style is="custom-style">
+
+    section {
+      -webkit-tap-highlight-color: rgba(0,0,0,0);
+    }
+    
     section > paper-button {
       background-color: var(--google-grey-300);
       padding: 5px;


### PR DESCRIPTION
Fixes #29 by applying css to remove highlight. Needed for safari mobile, where otherwise clicking on a section causes a flashy effect like this:
![flashy-dialog](https://cloud.githubusercontent.com/assets/6173664/11704379/261c871e-9e9c-11e5-8046-46c1e107a333.gif)
With this fix, it looks like this:
![not-flashy-dialog](https://cloud.githubusercontent.com/assets/6173664/11704391/40ff087c-9e9c-11e5-80ae-5e24ce295be6.gif)
