### PR TITLE
cancel previous animation before playing new one

### DIFF
--- a/paper-dialog.html
+++ b/paper-dialog.html
@@ -92,6 +92,7 @@ element.
     },
 
     _renderOpened: function() {
+      this.cancelAnimation();
       if (this.withBackdrop) {
         this.backdropElement.open();
       }
@@ -99,6 +100,7 @@ element.
     },
 
     _renderClosed: function() {
+      this.cancelAnimation();
       if (this.withBackdrop) {
         this.backdropElement.close();
       }


### PR DESCRIPTION
Contributes in fixing #77 by canceling previous animations before triggering new ones.
The fix will be completed once https://github.com/PolymerElements/iron-overlay-behavior/pull/84 is merged.
