### PR TITLE
delegate backdropElement handling to iron-overlay-manager

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "neon-animation": "PolymerElements/neon-animation#^1.0.0",
     "paper-dialog-behavior": "PolymerElements/paper-dialog-behavior#^1.0.0",
+    "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#^1.7.0",
     "paper-styles": "PolymerElements/paper-styles#^1.0.0",
     "polymer": "Polymer/polymer#^1.1.0"
   },

--- a/paper-dialog.html
+++ b/paper-dialog.html
@@ -94,17 +94,11 @@ element.
 
     _renderOpened: function() {
       this.cancelAnimation();
-      if (this.withBackdrop) {
-        this.backdropElement.open();
-      }
       this.playAnimation('entry');
     },
 
     _renderClosed: function() {
       this.cancelAnimation();
-      if (this.withBackdrop) {
-        this.backdropElement.close();
-      }
       this.playAnimation('exit');
     },
 

--- a/test/paper-dialog.html
+++ b/test/paper-dialog.html
@@ -33,6 +33,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="modal">
+    <template>
+      <paper-dialog modal>
+        <p>Dialog</p>
+      </paper-dialog>
+    </template>
+  </test-fixture>
+
   <test-fixture id="opened-modals">
     <template>
       <paper-dialog modal opened>
@@ -48,14 +56,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     suite('modal', function() {
 
-      test('backdrop element remains opened when closing top modal', function(done) {
-        var modal = fixture('opened-modals')[1];
-        modal.addEventListener('iron-overlay-opened', function() {
-          assert.isTrue(modal.backdropElement.opened, 'backdrop is open');
-          modal.close();
+      test('backdrop element remains opened when closing top modal, closes when all modals are closed', function(done) {
+        var modals = fixture('opened-modals');
+        modals[1].addEventListener('iron-overlay-opened', function() {
+          assert.isTrue(modals[1].backdropElement.opened, 'backdrop is open');
+          modals[1].close();
         });
-        modal.addEventListener('iron-overlay-closed', function() {
-          assert.isTrue(modal.backdropElement.opened, 'backdrop is still open');
+        modals[1].addEventListener('iron-overlay-closed', function() {
+          assert.isTrue(modals[1].backdropElement.opened, 'backdrop is still open');
+          modals[0].close();
+        });
+        modals[0].addEventListener('iron-overlay-closed', function() {
+          assert.isFalse(modals[0].backdropElement.opened, 'backdrop is closed');
           done();
         });
       });
@@ -63,6 +75,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     suite('a11y', function() {
+      a11ySuite('basic', []);
+
+      a11ySuite('modal', []);
 
       test('dialog has role="dialog"', function() {
         var dialog = fixture('basic');

--- a/test/paper-dialog.html
+++ b/test/paper-dialog.html
@@ -9,41 +9,69 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <html>
-  <head>
 
-    <title>paper-dialog tests</title>
+<head>
 
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+  <title>paper-dialog tests</title>
 
-    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-    <script src="../../web-component-tester/browser.js"></script>
-    <link rel="import" href="../paper-dialog.html">
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
 
-  </head>
-  <body>
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+  <link rel="import" href="../paper-dialog.html">
+</head>
 
-    <test-fixture id="basic">
-      <template>
-        <paper-dialog>
-          <p>Dialog</p>
-        </paper-dialog>
-      </template>
-    </test-fixture>
+<body>
 
-    <script>
+  <test-fixture id="basic">
+    <template>
+      <paper-dialog>
+        <p>Dialog</p>
+      </paper-dialog>
+    </template>
+  </test-fixture>
 
-      suite('a11y', function() {
+  <test-fixture id="opened-modals">
+    <template>
+      <paper-dialog modal opened>
+        <p>Dialog 1</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+      </paper-dialog>
+      <paper-dialog modal opened>
+        <p>Dialog 2</p>
+      </paper-dialog>
+    </template>
+  </test-fixture>
 
-        test('dialog has role="dialog"', function() {
-          var dialog = fixture('basic');
-          assert.equal(dialog.getAttribute('role'), 'dialog', 'has role="dialog"');
+  <script>
+    suite('modal', function() {
+
+      test('backdrop element remains opened when closing top modal', function(done) {
+        var modal = fixture('opened-modals')[1];
+        modal.addEventListener('iron-overlay-opened', function() {
+          assert.isTrue(modal.backdropElement.opened, 'backdrop is open');
+          modal.close();
         });
-
+        modal.addEventListener('iron-overlay-closed', function() {
+          assert.isTrue(modal.backdropElement.opened, 'backdrop is still open');
+          done();
+        });
       });
 
-    </script>
+    });
 
-  </body>
+    suite('a11y', function() {
+
+      test('dialog has role="dialog"', function() {
+        var dialog = fixture('basic');
+        assert.equal(dialog.getAttribute('role'), 'dialog', 'has role="dialog"');
+      });
+
+    });
+  </script>
+
+</body>
+
 </html>


### PR DESCRIPTION
Fixes #113, the `backdropElement` opening/closing is already handled by [`iron-overlay-manager`](https://github.com/PolymerElements/iron-overlay-behavior/blob/master/iron-overlay-manager.html#L229)
