### PR TITLE
Enable clients to use CSS animations.

### DIFF
--- a/paper-dialog.html
+++ b/paper-dialog.html
@@ -100,7 +100,7 @@ element.
     _renderOpened: function() {
       this._removeAnimationClasses();
 
-      // Adding the .paper-dialog-opening css class allows parent clients of
+      // Adding the .paper-dialog-opening css class allows clients of
       // this component to use CSS animations to animate opening the dialog.
       this.toggleClass(ANIMATION_CSS_CLASSES.OPENING, true);
 
@@ -114,7 +114,7 @@ element.
     _renderClosed: function() {
       this._removeAnimationClasses();
 
-      // Adding the .paper-dialog-closing css class allows parent clients of
+      // Adding the .paper-dialog-closing css class allows clients of
       // this component to use CSS animations to animate closing the dialog.
       this.toggleClass(ANIMATION_CSS_CLASSES.CLOSING, true);
 

--- a/paper-dialog.html
+++ b/paper-dialog.html
@@ -79,6 +79,11 @@ element.
 
 (function() {
 
+  var ANIMATION_CSS_CLASSES = {
+    OPENING: 'paper-dialog-opening',
+    CLOSING: 'paper-dialog-closing'
+  };
+
   Polymer({
 
     is: 'paper-dialog',
@@ -93,12 +98,30 @@ element.
     },
 
     _renderOpened: function() {
+      this._removeAnimationClasses();
+
+      // Adding the .paper-dialog-opening css class allows parent clients of
+      // this component to use CSS animations to animate opening the dialog.
+      this.toggleClass(ANIMATION_CSS_CLASSES.OPENING, true);
+
       this.cancelAnimation();
+      if (this.withBackdrop) {
+        this.backdropElement.open();
+      }
       this.playAnimation('entry');
     },
 
     _renderClosed: function() {
+      this._removeAnimationClasses();
+
+      // Adding the .paper-dialog-closing css class allows parent clients of
+      // this component to use CSS animations to animate closing the dialog.
+      this.toggleClass(ANIMATION_CSS_CLASSES.CLOSING, true);
+
       this.cancelAnimation();
+      if (this.withBackdrop) {
+        this.backdropElement.close();
+      }
       this.playAnimation('exit');
     },
 
@@ -108,6 +131,13 @@ element.
       } else {
         this._finishRenderClosed();
       }
+    },
+
+    _removeAnimationClasses: function() {
+      Object.keys(ANIMATION_CSS_CLASSES).forEach(function(key) {
+        var cssClass = ANIMATION_CSS_CLASSES[key];
+        this.toggleClass(cssClass, false);
+      }.bind(this));
     }
 
   });


### PR DESCRIPTION
This is an idea that solves an issue we were experiencing with the paper-dialog. We found that modifying the existing animations (ie "scale-up-animation") would require either implementing our own web animation or providing some sort of global animation configuration.

Using CSS animations is an easy way for us to apply an animation to all of our paper-dialog instances, however, there was no decent way to target dialogs that are opening/closing.

This PR adds classes when the dialog is opened (or closed). This PR also resolves issue #119 (or at least provides a workaround).
